### PR TITLE
Arrow package now correct exports defines

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,5 +36,6 @@
 .vs/
 .vscode/
 build*/
+env/
 out/
 data/

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -17,11 +17,6 @@ target_link_libraries(profitview
         fmt::fmt
 )
 
-target_compile_definitions(profitview
-    INTERFACE
-        PARQUET_STATIC # Workaround required until this PR is merged: https://github.com/conan-io/conan-center-index/pull/14376
-)
-
 target_compile_options(profitview
     INTERFACE
         $<$<CXX_COMPILER_ID:Clang>:-stdlib=libc++>


### PR DESCRIPTION
This is no longer needed as I fixed the issue in the source package: https://github.com/conan-io/conan-center-index/issues/14374